### PR TITLE
add missing methods for termvars

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "StandardizedPredictors"
 uuid = "5064a6a7-f8c2-40e2-8bdc-797ec6f1ae18"
 authors = "Beacon Biosignals, inc."
-version = "0.1.2"
+version = "0.1.3"
 
 [deps]
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"

--- a/src/centering.jl
+++ b/src/centering.jl
@@ -178,3 +178,4 @@ StatsModels.width(t::CenteredTerm) = StatsModels.width(t.term)
 # don't generate schema entries for terms which are already centered
 StatsModels.needs_schema(::CenteredTerm) = false
 StatsModels.termsyms(t::CenteredTerm) = StatsModels.termsyms(t.term)
+StatsModels.termvars(t::CenteredTerm) = StatsModels.termvars(t.term)

--- a/src/scaling.jl
+++ b/src/scaling.jl
@@ -173,3 +173,4 @@ StatsModels.width(t::ScaledTerm) = StatsModels.width(t.term)
 # don't generate schema entries for terms which are already scaled
 StatsModels.needs_schema(::ScaledTerm) = false
 StatsModels.termsyms(t::ScaledTerm) = StatsModels.termsyms(t.term)
+StatsModels.termvars(t::ScaledTerm) = StatsModels.termvars(t.term)

--- a/src/zscoring.jl
+++ b/src/zscoring.jl
@@ -140,3 +140,4 @@ StatsModels.width(t::ZScoredTerm) = StatsModels.width(t.term)
 # don't generate schema entries for terms which are already scaled
 StatsModels.needs_schema(::ZScoredTerm) = false
 StatsModels.termsyms(t::ZScoredTerm) = StatsModels.termsyms(t.term)
+StatsModels.termvars(t::ZScoredTerm) = StatsModels.termvars(t.term)

--- a/test/centering.jl
+++ b/test/centering.jl
@@ -98,6 +98,14 @@
         # round-trip schema is empty since needs_schema is false
         sch_2 = schema(ff_c, data)
         @test isempty(sch_2.schema)
+
+        @testset "missing omit" begin
+            d = (x=[1, 2, missing, 3], y=[1, missing, 2, 3], z=[missing, 1, 2, 3])
+            dd, nonmissing = StatsModels.missing_omit(d, ff_c)
+            @test findall(nonmissing) == [1, 4]
+            @test dd.x == d.x[nonmissing]
+            @test dd.y == d.y[nonmissing]
+        end            
     end
 
     @testset "printing" begin

--- a/test/centering.jl
+++ b/test/centering.jl
@@ -105,7 +105,7 @@
             @test findall(nonmissing) == [1, 4]
             @test dd.x == d.x[nonmissing]
             @test dd.y == d.y[nonmissing]
-        end            
+        end
     end
 
     @testset "printing" begin

--- a/test/scaling.jl
+++ b/test/scaling.jl
@@ -97,6 +97,16 @@
         # round-trip schema is empty since needs_schema is false
         sch_2 = schema(ff_c, data)
         @test isempty(sch_2.schema)
+
+        @testset "missing omit" begin
+            d = (x=[1, 2, missing, 3], y=[1, missing, 2, 3], z=[missing, 1, 2, 3])
+            dd, nonmissing = StatsModels.missing_omit(d, ff_c)
+            # z is ignored:
+            @test findall(nonmissing) == [1, 4]
+            # x and y are handled correclty
+            @test dd.x == d.x[nonmissing]
+            @test dd.y == d.y[nonmissing]
+        end            
     end
 
     @testset "printing" begin

--- a/test/scaling.jl
+++ b/test/scaling.jl
@@ -106,7 +106,7 @@
             # x and y are handled correclty
             @test dd.x == d.x[nonmissing]
             @test dd.y == d.y[nonmissing]
-        end            
+        end
     end
 
     @testset "printing" begin

--- a/test/zscoring.jl
+++ b/test/zscoring.jl
@@ -88,7 +88,7 @@
             # x and y are handled correclty
             @test dd.x == d.x[nonmissing]
             @test dd.y == d.y[nonmissing]
-        end            
+        end
     end
 
     @testset "printing" begin

--- a/test/zscoring.jl
+++ b/test/zscoring.jl
@@ -79,6 +79,16 @@
         # round-trip schema is empty since needs_schema is false
         sch_2 = schema(ff_c, data)
         @test isempty(sch_2.schema)
+
+        @testset "missing omit" begin
+            d = (x=[1, 2, missing, 3], y=[1, missing, 2, 3], z=[missing, 1, 2, 3])
+            dd, nonmissing = StatsModels.missing_omit(d, ff_c)
+            # z is ignored:
+            @test findall(nonmissing) == [1, 4]
+            # x and y are handled correclty
+            @test dd.x == d.x[nonmissing]
+            @test dd.y == d.y[nonmissing]
+        end            
     end
 
     @testset "printing" begin


### PR DESCRIPTION
These are needed for `missing_omit` and hence `predict`.  Adds integration tests
for this via `missing_omit`.