### PR TITLE
Support `Center(::Function)`, `Scale(::Function)`, `ZScore(;center::Function, scale::Function)`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "StandardizedPredictors"
 uuid = "5064a6a7-f8c2-40e2-8bdc-797ec6f1ae18"
 authors = "Beacon Biosignals, inc."
-version = "0.1.3"
+version = "0.1.4"
 
 [deps]
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,18 +1,19 @@
 using StandardizedPredictors
 using Documenter
 
-DocMeta.setdocmeta!(StandardizedPredictors, :DocTestSetup, :(using StandardizedPredictors); recursive=true)
+DocMeta.setdocmeta!(StandardizedPredictors, :DocTestSetup, :(using StandardizedPredictors);
+                    recursive=true)
 
-makedocs(modules=[StandardizedPredictors],
+makedocs(; modules=[StandardizedPredictors],
          authors="Beacon Biosignals, Inc.",
          repo="https://github.com/beacon-biosignals/StandardizedPredictors.jl/blob/{commit}{path}#{line}",
          sitename="StandardizedPredictors.jl",
-         format=Documenter.HTML(prettyurls=get(ENV, "CI", "false") == "true",
+         format=Documenter.HTML(; prettyurls=get(ENV, "CI", "false") == "true",
                                 canonical="https://beacon-biosignals.github.io/StandardizedPredictors.jl",
                                 assets=String[]),
          pages=["Home" => "index.md",
                 "API" => "api.md"])
 
-deploydocs(repo="github.com/beacon-biosignals/StandardizedPredictors.jl",
+deploydocs(; repo="github.com/beacon-biosignals/StandardizedPredictors.jl",
            devbranch="main",
            push_preview=true)

--- a/src/StandardizedPredictors.jl
+++ b/src/StandardizedPredictors.jl
@@ -18,6 +18,18 @@ using StatsModels
 using StatsBase
 using Statistics
 
+"""
+    _standard(xs::AbstractArray, val)
+
+Translate an abstract standardization value to a concrete one based on `xs`.
+
+`nothing` and already concrete `Number` `val`s are passed through.
+Otherwise, `val(xs)` is returned.
+"""
+_standard(::AbstractArray, t::Number) = t
+_standard(::AbstractArray, ::Nothing) = nothing
+_standard(xs::AbstractArray, t) = t(xs)
+
 include("utils.jl")
 include("centering.jl")
 include("scaling.jl")

--- a/src/StandardizedPredictors.jl
+++ b/src/StandardizedPredictors.jl
@@ -1,18 +1,18 @@
 module StandardizedPredictors
 
 export
-    center,
-    center!,
-    Center,
-    CenteredTerm,
-    scale,
-    scale!,
-    Scale,
-    ScaledTerm,
-    zscore,    # from StatsBase
-    zscore!,   # from StatsBase
-    ZScore,
-    ZScoredTerm
+       center,
+       center!,
+       Center,
+       CenteredTerm,
+       scale,
+       scale!,
+       Scale,
+       ScaledTerm,
+       zscore,    # from StatsBase
+       zscore!,   # from StatsBase
+       ZScore,
+       ZScoredTerm
 
 using StatsModels
 using StatsBase

--- a/src/centering.jl
+++ b/src/centering.jl
@@ -150,7 +150,7 @@ end
 Center(xs::AbstractArray, c::Center) = Center(xs, c.center, c)
 # pass through
 Center(::AbstractArray, ::Nothing, parent) = Center(nothing)
-Center(xs::AbstractArray, c, parent) = c(xs)
+Center(xs::AbstractArray, c, parent) = Center(c(xs))
 Center(::AbstractArray, c::Number, parent) = parent
 
 function StatsModels.concrete_term(t::Term, xs::AbstractArray, c::Center)

--- a/src/centering.jl
+++ b/src/centering.jl
@@ -54,7 +54,13 @@ StatsModels.Schema with 1 entry:
   x => center(x, 5)
 ```
 
-Or center will be automatically computed if left out:
+You can use a function to compute the center value:
+
+julia> schema((x=collect(1:10), ), Dict(:x => Center(median)))
+StatsModels.Schema with 1 entry:
+  x => x(centered: 5.5)
+
+Or [`center`](@ref) will be automatically computed if omitted:
 
 ```
 julia> schema((x=collect(1:10), ), Dict(:x => Center()))
@@ -67,7 +73,6 @@ struct Center{T}
 end
 
 Center() = Center(nothing)
-
 
 """
     struct CenteredTerm{T,C} <: AbstractTerm

--- a/src/centering.jl
+++ b/src/centering.jl
@@ -73,6 +73,7 @@ struct Center
 end
 
 Center() = Center(nothing)
+Center(xs::AbstractArray, c::Center) = Center(_standard(xs, c.center))
 
 """
     struct CenteredTerm{T,C} <: AbstractTerm
@@ -146,8 +147,6 @@ struct CenteredTerm{T,C} <: AbstractTerm
     term::T
     center::C
 end
-
-Center(xs::AbstractArray, c::Center) = Center(_standard(xs, c.center))
 
 function StatsModels.concrete_term(t::Term, xs::AbstractArray, c::Center)
     return center(StatsModels.concrete_term(t, xs, nothing), Center(xs, c))

--- a/src/centering.jl
+++ b/src/centering.jl
@@ -157,10 +157,13 @@ end
 center(t::ContinuousTerm, c::Center) = CenteredTerm(t, something(c.center, t.mean))
 center(t::ContinuousTerm, c) = CenteredTerm(t, c)
 center(t::ContinuousTerm) = CenteredTerm(t, t.mean)
-center(t::AbstractTerm) = throw(ArgumentError("can only compute center for ContinuousTerm; must provide center value via center(t, c)"))
+function center(t::AbstractTerm)
+    throw(ArgumentError("can only compute center for ContinuousTerm; must provide center value via center(t, c)"))
+end
 
 function center(t::AbstractTerm, c::Center)
-    c.center !== nothing || throw(ArgumentError("can only compute center for ContinuousTerm; must provide center via center(t, c)"))
+    c.center !== nothing ||
+        throw(ArgumentError("can only compute center for ContinuousTerm; must provide center via center(t, c)"))
     return CenteredTerm(t, c.center)
 end
 
@@ -177,7 +180,9 @@ end
 # coef table: "x(centered: 5.5)"
 Base.show(io::IO, t::CenteredTerm) = print(io, "$(t.term)(centered: $(_round(t.center)))")
 # regular show: "x(centered: 5.5)", used in displaying schema dicts
-Base.show(io::IO, ::MIME"text/plain", t::CenteredTerm) = print(io, "$(t.term)(centered: $(_round(t.center)))")
+function Base.show(io::IO, ::MIME"text/plain", t::CenteredTerm)
+    return print(io, "$(t.term)(centered: $(_round(t.center)))")
+end
 # long show: "x(centered: 5.5)"
 
 # statsmodels glue code:

--- a/src/centering.jl
+++ b/src/centering.jl
@@ -147,11 +147,7 @@ struct CenteredTerm{T,C} <: AbstractTerm
     center::C
 end
 
-Center(xs::AbstractArray, c::Center) = Center(xs, c.center, c)
-# pass through
-Center(::AbstractArray, ::Nothing, parent) = Center(nothing)
-Center(xs::AbstractArray, c, parent) = Center(c(xs))
-Center(::AbstractArray, c::Number, parent) = parent
+Center(xs::AbstractArray, c::Center) = Center(_standard(xs, c.center))
 
 function StatsModels.concrete_term(t::Term, xs::AbstractArray, c::Center)
     return center(StatsModels.concrete_term(t, xs, nothing), Center(xs, c))

--- a/src/centering.jl
+++ b/src/centering.jl
@@ -39,7 +39,7 @@ function center!(x, y)
 end
 
 """
-    struct Center{T}
+    struct Center
 
 Represents a centering scheme, akin to `StatsModels.AbstractContrasts`.  Pass as
 value in `Dict` as hints to `schema` (or as `contrasts` kwarg for `fit`).
@@ -68,8 +68,8 @@ StatsModels.Schema with 1 entry:
   x => center(x, 5.5)
 ```
 """
-struct Center{T}
-    center::T
+struct Center
+    center::Any
 end
 
 Center() = Center(nothing)
@@ -147,13 +147,14 @@ struct CenteredTerm{T,C} <: AbstractTerm
     center::C
 end
 
-function StatsModels.concrete_term(t::Term, xs::AbstractArray, c::Center{T}) where T <: Union{Number, Nothing}
-    return center(StatsModels.concrete_term(t, xs, nothing), c)
-end
+Center(xs::AbstractArray, c::Center) = Center(xs, c.center, c)
+# pass through
+Center(::AbstractArray, ::Nothing, parent) = Center(nothing)
+Center(xs::AbstractArray, c, parent) = c(xs)
+Center(::AbstractArray, c::Number, parent) = parent
 
 function StatsModels.concrete_term(t::Term, xs::AbstractArray, c::Center)
-    c_empirical = Center(c.center(xs))
-    return center(StatsModels.concrete_term(t, xs, nothing), c_empirical)
+    return center(StatsModels.concrete_term(t, xs, nothing), Center(xs, c))
 end
 
 # run-time constructors:

--- a/src/scaling.jl
+++ b/src/scaling.jl
@@ -68,6 +68,7 @@ struct Scale
 end
 
 Scale() = Scale(nothing)
+Scale(xs::AbstractArray, s::Scale) = Scale(_standard(xs, s.scale))
 
 """
     struct ScaledTerm{T,S} <: AbstractTerm
@@ -140,8 +141,6 @@ struct ScaledTerm{T,S} <: AbstractTerm
     term::T
     scale::S
 end
-
-Scale(xs::AbstractArray, s::Scale) = Scale(_standard(xs, s.scale))
 
 function StatsModels.concrete_term(t::Term, xs::AbstractArray, s::Scale)
     return scale(StatsModels.concrete_term(t, xs, nothing), Scale(xs, s))

--- a/src/scaling.jl
+++ b/src/scaling.jl
@@ -146,7 +146,7 @@ end
 Scale(xs::AbstractArray, s::Scale) = Scale(xs, s.scale, s)
 # pass through
 Scale(::AbstractArray, ::Nothing, parent) = Scale(nothing)
-Scale(xs::AbstractArray, s, parent) = s(xs)
+Scale(xs::AbstractArray, s, parent) = Scale(s(xs))
 Scale(::AbstractArray, s::Number, parent) = parent
 
 function StatsModels.concrete_term(t::Term, xs::AbstractArray, s::Scale)

--- a/src/scaling.jl
+++ b/src/scaling.jl
@@ -69,7 +69,6 @@ end
 
 Scale() = Scale(nothing)
 
-
 """
     struct ScaledTerm{T,S} <: AbstractTerm
 
@@ -152,10 +151,13 @@ end
 scale(t::ContinuousTerm, s::Scale) = ScaledTerm(t, something(s.scale, sqrt(t.var)))
 scale(t::ContinuousTerm, s) = ScaledTerm(t, s)
 scale(t::ContinuousTerm) = ScaledTerm(t, sqrt(t.var))
-scale(t::AbstractTerm) = throw(ArgumentError("can only compute scale for ContinuousTerm; must provide scale value via scale(t, s)"))
+function scale(t::AbstractTerm)
+    throw(ArgumentError("can only compute scale for ContinuousTerm; must provide scale value via scale(t, s)"))
+end
 
 function scale(t::AbstractTerm, s::Scale)
-    s.scale !== nothing || throw(ArgumentError("can only compute scale for ContinuousTerm; must provide scale via scale(t, s)"))
+    s.scale !== nothing ||
+        throw(ArgumentError("can only compute scale for ContinuousTerm; must provide scale via scale(t, s)"))
     return ScaledTerm(t, s.scale)
 end
 
@@ -173,7 +175,9 @@ end
 # coef table: "x(scaled: 5.5)"
 Base.show(io::IO, t::ScaledTerm) = print(io, "$(t.term)(scaled: $(_round(t.scale)))")
 # regular show: "x(scaled: 5.5)", used in displaying schema dicts
-Base.show(io::IO, ::MIME"text/plain", t::ScaledTerm) = print(io, "$(t.term)(scaled: $(_round(t.scale)))")
+function Base.show(io::IO, ::MIME"text/plain", t::ScaledTerm)
+    return print(io, "$(t.term)(scaled: $(_round(t.scale)))")
+end
 # long show: "x(scaled: 5.5)"
 
 # statsmodels glue code:

--- a/src/scaling.jl
+++ b/src/scaling.jl
@@ -142,12 +142,7 @@ struct ScaledTerm{T,S} <: AbstractTerm
     scale::S
 end
 
-
-Scale(xs::AbstractArray, s::Scale) = Scale(xs, s.scale, s)
-# pass through
-Scale(::AbstractArray, ::Nothing, parent) = Scale(nothing)
-Scale(xs::AbstractArray, s, parent) = Scale(s(xs))
-Scale(::AbstractArray, s::Number, parent) = parent
+Scale(xs::AbstractArray, s::Scale) = Scale(_standard(xs, s.scale))
 
 function StatsModels.concrete_term(t::Term, xs::AbstractArray, s::Scale)
     return scale(StatsModels.concrete_term(t, xs, nothing), Scale(xs, s))

--- a/src/zscoring.jl
+++ b/src/zscoring.jl
@@ -116,30 +116,45 @@ function StatsModels.concrete_term(t::Term, xs::AbstractArray, z::ZScore)
 end
 
 # run-time constructors:
-StatsBase.zscore(t::ContinuousTerm, z::ZScore) = ZScoredTerm(t, something(z.center, t.mean), something(z.scale, sqrt(t.var)))
-StatsBase.zscore(t::ContinuousTerm; center=nothing, scale=nothing) = ZScoredTerm(t, center, scale)
-StatsBase.zscore(t::AbstractTerm) = throw(ArgumentError("can only compute z-score for ContinuousTerm; must provide scale value via zscore(t; center, scale)"))
+function StatsBase.zscore(t::ContinuousTerm, z::ZScore)
+    return ZScoredTerm(t, something(z.center, t.mean), something(z.scale, sqrt(t.var)))
+end
+function StatsBase.zscore(t::ContinuousTerm; center=nothing, scale=nothing)
+    return ZScoredTerm(t, center, scale)
+end
+function StatsBase.zscore(t::AbstractTerm)
+    throw(ArgumentError("can only compute z-score for ContinuousTerm; must provide scale value via zscore(t; center, scale)"))
+end
 
 function StatsBase.zscore(t::AbstractTerm, z::ZScore)
-    z.scale !== nothing && z.center !== nothing || throw(ArgumentError("can only compute z-score for ContinuousTerm; must provide scale via zscore(t; center, scale)"))
+    z.scale !== nothing && z.center !== nothing ||
+        throw(ArgumentError("can only compute z-score for ContinuousTerm; must provide scale via zscore(t; center, scale)"))
     return ZScoredTerm(t, z.center, z.scale)
 end
 
-StatsModels.modelcols(t::ZScoredTerm, d::NamedTuple) = zscore(modelcols(t.term, d), t.center, t.scale)
+function StatsModels.modelcols(t::ZScoredTerm, d::NamedTuple)
+    return zscore(modelcols(t.term, d), t.center, t.scale)
+end
 
 function StatsBase.coefnames(t::ZScoredTerm)
     if StatsModels.width(t.term) == 1
         return "$(coefnames(t.term))(centered: $(_round(t.center)) scaled: $(_round(t.scale)))"
     elseif length(t.scale) > 1
-        return string.(vec(coefnames(t.term)), "(centered: ", _round.(vec(t.center)), " scaled: ", _round.(vec(t.scale)), ")")
+        return string.(vec(coefnames(t.term)), "(centered: ", _round.(vec(t.center)),
+                       " scaled: ", _round.(vec(t.scale)), ")")
     else
-        return string.(coefnames(t.term), "(centered: ", _round(t.center), " scaled: ", _round(t.scale), ")")
+        return string.(coefnames(t.term), "(centered: ", _round(t.center), " scaled: ",
+                       _round(t.scale), ")")
     end
 end
 # coef table: "x(scaled: 5.5)"
-Base.show(io::IO, t::ZScoredTerm) = print(io, "$(t.term)(centered: $(_round(t.center)) scaled: $(_round(t.scale)))")
+function Base.show(io::IO, t::ZScoredTerm)
+    return print(io, "$(t.term)(centered: $(_round(t.center)) scaled: $(_round(t.scale)))")
+end
 # regular show: "x(scaled: 5.5)", used in displaying schema dicts
-Base.show(io::IO, ::MIME"text/plain", t::ZScoredTerm) = print(io, "$(t.term)(centered: $(_round(t.center)) scaled: $(_round(t.scale)))")
+function Base.show(io::IO, ::MIME"text/plain", t::ZScoredTerm)
+    return print(io, "$(t.term)(centered: $(_round(t.center)) scaled: $(_round(t.scale)))")
+end
 # long show: "x(scaled: 5.5)"
 
 # statsmodels glue code:

--- a/src/zscoring.jl
+++ b/src/zscoring.jl
@@ -105,8 +105,15 @@ struct ZScoredTerm{T,C,S} <: AbstractTerm
     scale::S
 end
 
-StatsModels.concrete_term(t::Term, xs::AbstractArray, z::ZScore) =
-    zscore(StatsModels.concrete_term(t, xs, nothing), z)
+function ZScore(xs::AbstractArray, zs::ZScore)
+    center = _standard(xs, zs.center)
+    scale = _standard(xs, zs.scale)
+    return ZScore(center, scale)
+end
+
+function StatsModels.concrete_term(t::Term, xs::AbstractArray, z::ZScore)
+    return zscore(StatsModels.concrete_term(t, xs, nothing), ZScore(xs, z))
+end
 
 # run-time constructors:
 StatsBase.zscore(t::ContinuousTerm, z::ZScore) = ZScoredTerm(t, something(z.center, t.mean), something(z.scale, sqrt(t.var)))

--- a/src/zscoring.jl
+++ b/src/zscoring.jl
@@ -29,6 +29,12 @@ end
 
 ZScore(; center=nothing, scale=nothing) = ZScore(center, scale)
 
+function ZScore(xs::AbstractArray, zs::ZScore)
+    center = _standard(xs, zs.center)
+    scale = _standard(xs, zs.scale)
+    return ZScore(center, scale)
+end
+
 """
     struct ZScoredTerm{T,C,S} <: AbstractTerm
 
@@ -103,12 +109,6 @@ struct ZScoredTerm{T,C,S} <: AbstractTerm
     term::T
     center::C
     scale::S
-end
-
-function ZScore(xs::AbstractArray, zs::ZScore)
-    center = _standard(xs, zs.center)
-    scale = _standard(xs, zs.scale)
-    return ZScore(center, scale)
 end
 
 function StatsModels.concrete_term(t::Term, xs::AbstractArray, z::ZScore)

--- a/test/centering.jl
+++ b/test/centering.jl
@@ -1,5 +1,4 @@
 @testset "Centering" begin
-
     data = (x=collect(1:10),
             y=rand(10) .+ 3,
             z=Symbol.(repeat('a':'e', 2)))
@@ -83,7 +82,7 @@
             center!(mean, copy(x)) == center(mean, x)
             @test_throws ArgumentError center!(mean, [1, 2])
             @test_throws ArgumentError center!([1, 2])
-            @test_throws MethodError center!(v -> 1, ["a","b"])
+            @test_throws MethodError center!(v -> 1, ["a", "b"])
         end
     end
 
@@ -100,7 +99,8 @@
                            data.y .- 2,
                            (data.x .- mean(data.x)) .* (data.y .- 2))
 
-        @test coefnames(ff_c.rhs) == ["x(centered: 5.5)", "y(centered: 2)", "x(centered: 5.5) & y(centered: 2)"]
+        @test coefnames(ff_c.rhs) ==
+              ["x(centered: 5.5)", "y(centered: 2)", "x(centered: 5.5) & y(centered: 2)"]
 
         # round-trip schema is empty since needs_schema is false
         sch_2 = schema(ff_c, data)
@@ -133,11 +133,11 @@
 
         zc2 = center(z, Center([1 2 3 4]))
         @test modelcols(zc2, data) == modelcols(z, data) .- [1 2 3 4]
-        @test coefnames(zc2) == coefnames(z) .* "(centered: " .* string.([1, 2, 3, 4]) .* ")"
+        @test coefnames(zc2) ==
+              coefnames(z) .* "(centered: " .* string.([1, 2, 3, 4]) .* ")"
     end
 
     # @testset "utilities" begin
-
 
     # end
 

--- a/test/centering.jl
+++ b/test/centering.jl
@@ -15,10 +15,15 @@
         @test modelcols(yc, data) == data.y .- mean(data.y) == data.y .- yc.center
 
         @testset "alternative center function" begin
-            xc = concrete_term(term(:x), data, Center(median))
+            f = first
+            xc = concrete_term(term(:x), data, Center(f))
             @test xc isa CenteredTerm
-            @test xc.center == median(data.x)
-            @test modelcols(xc, data) == data.x .- median(data.x) == data.x .- xc.center
+            @test xc.center == f(data.x)
+            @test modelcols(xc, data) == data.x .- f(data.x) == data.x .- xc.center
+            # why test this? well this makes sure that our tests
+            # wouldn't pass if we were using the default center function
+            # in other words, this tests we're actually hitting a different codepath
+            @test !isapprox(mean(data.x), f(data.x))
         end
     end
 

--- a/test/centering.jl
+++ b/test/centering.jl
@@ -14,6 +14,13 @@
         @test yc isa CenteredTerm
         @test yc.center == mean(data.y)
         @test modelcols(yc, data) == data.y .- mean(data.y) == data.y .- yc.center
+
+        @testset "alternative center function" begin
+            xc = concrete_term(term(:x), data, Center(median))
+            @test xc isa CenteredTerm
+            @test xc.center == median(data.x)
+            @test modelcols(xc, data) == data.x .- median(data.x) == data.x .- xc.center
+        end
     end
 
     @testset "Manual centering" begin

--- a/test/scaling.jl
+++ b/test/scaling.jl
@@ -14,6 +14,13 @@
         @test yc isa ScaledTerm
         @test yc.scale == std(data.y)
         @test modelcols(yc, data) == data.y ./ std(data.y) == data.y ./ yc.scale
+
+        @testset "alternative scale function" begin
+            xc = concrete_term(term(:x), data, Scale(mad))
+            @test xc isa ScaledTerm
+            @test xc.scale == mad(data.x)
+            @test modelcols(xc, data) == data.x ./ mad(data.x) == data.x ./ xc.scale
+        end
     end
 
     @testset "Manual scaling" begin

--- a/test/scaling.jl
+++ b/test/scaling.jl
@@ -15,10 +15,15 @@
         @test modelcols(yc, data) == data.y ./ std(data.y) == data.y ./ yc.scale
 
         @testset "alternative scale function" begin
-            xc = concrete_term(term(:x), data, Scale(mad))
+            f = mad
+            xc = concrete_term(term(:x), data, Scale(f))
             @test xc isa ScaledTerm
-            @test xc.scale == mad(data.x)
-            @test modelcols(xc, data) == data.x ./ mad(data.x) == data.x ./ xc.scale
+            @test xc.scale == f(data.x)
+            @test modelcols(xc, data) == data.x ./ f(data.x) == data.x ./ xc.scale
+            # why test this? well this makes sure that our tests
+            # wouldn't pass if we were using the default scale function
+            # in other words, this tests we're actually hitting a different codepath
+            @test !isapprox(std(data.x), f(data.x))
         end
     end
 

--- a/test/scaling.jl
+++ b/test/scaling.jl
@@ -1,5 +1,4 @@
 @testset "Scaling" begin
-
     data = (x=collect(1:10),
             y=rand(10) .+ 3,
             z=Symbol.(repeat('a':'e', 2)))
@@ -65,8 +64,8 @@
         @testset "scaling vectors" begin
             x = collect(1:5) # int
             y = x * 5.0      # float
-            @test scale(x) ==  x ./ std(x)
-            @test scale(y) ==  y ./ std(y)
+            @test scale(x) == x ./ std(x)
+            @test scale(y) == y ./ std(y)
             @test scale(maximum, x) == (x ./ 5)
             @test all(scale(y, x) .== 5)
 
@@ -82,7 +81,7 @@
             @test scale!([2 4 6]) == scale([2 4 6])
             @test_throws InexactError scale!(std, [1, 2])
             @test_throws InexactError scale!([1, 2])
-            @test_throws MethodError scale!(v -> 1, ["a","b"])
+            @test_throws MethodError scale!(v -> 1, ["a", "b"])
         end
     end
 
@@ -99,7 +98,8 @@
                            data.y ./ 2,
                            (data.x ./ std(data.x)) .* (data.y ./ 2))
 
-        @test coefnames(ff_c.rhs) == ["x(scaled: 3.03)", "y(scaled: 2)", "x(scaled: 3.03) & y(scaled: 2)"]
+        @test coefnames(ff_c.rhs) ==
+              ["x(scaled: 3.03)", "y(scaled: 2)", "x(scaled: 3.03) & y(scaled: 2)"]
 
         # round-trip schema is empty since needs_schema is false
         sch_2 = schema(ff_c, data)

--- a/test/zscoring.jl
+++ b/test/zscoring.jl
@@ -1,5 +1,4 @@
 @testset "Z Scoring" begin
-
     data = (x=collect(1:10),
             y=rand(10) .+ 3,
             z=Symbol.(repeat('a':'e', 2)))
@@ -26,29 +25,30 @@
     end
 
     @testset "Manual scaling" begin
-        xc = concrete_term(term(:x), data, ZScore(center=5))
+        xc = concrete_term(term(:x), data, ZScore(; center=5))
         @test xc isa ZScoredTerm
         @test xc.center ≈ 5 != mean(data.x)
         @test xc.scale ≈ std(data.x)
         @test modelcols(xc, data) ≈ zscore(data.x, xc.center, xc.scale)
 
-        yc = concrete_term(term(:y), data, ZScore(scale=3))
+        yc = concrete_term(term(:y), data, ZScore(; scale=3))
         @test yc isa ZScoredTerm
         @test yc.center ≈ mean(data.y)
         @test yc.scale == 3 != std(data.y)
         @test modelcols(yc, data) ≈ zscore(data.y, yc.center, yc.scale)
 
-        yc = concrete_term(term(:y), data, ZScore(scale=3, center=1))
+        yc = concrete_term(term(:y), data, ZScore(; scale=3, center=1))
         @test yc isa ZScoredTerm
         @test yc.center ≈ 1 != mean(data.y)
         @test yc.scale == 3 != std(data.y)
         @test modelcols(yc, data) ≈ zscore(data.y, yc.center, yc.scale)
 
-        @test zscore(concrete_term(term(:x), data, nothing); center=3, scale=5) == concrete_term(term(:x), data, ZScore(;center=3, scale=5))
+        @test zscore(concrete_term(term(:x), data, nothing); center=3, scale=5) ==
+              concrete_term(term(:x), data, ZScore(; center=3, scale=5))
     end
 
     @testset "Schema hints dict" begin
-        sch = schema(data, Dict(:x => ZScore(), :y => ZScore(center=2.2,scale=5)))
+        sch = schema(data, Dict(:x => ZScore(), :y => ZScore(; center=2.2, scale=5)))
         xc = sch[term(:x)]
         @test xc isa ZScoredTerm
         @test !StatsModels.needs_schema(xc)
@@ -72,7 +72,7 @@
 
         sch = schema(f, data)
 
-        sch_c = schema(f, data, Dict(:x => ZScore(), :y => ZScore(center=2.2,scale=5)))
+        sch_c = schema(f, data, Dict(:x => ZScore(), :y => ZScore(; center=2.2, scale=5)))
         ff_c = apply_schema(f, sch_c)
 
         mm_c = modelcols(ff_c.rhs, data)
@@ -80,9 +80,9 @@
                           zscore(data.y, 2.2, 5),
                           zscore(data.x) .* zscore(data.y, 2.2, 5))
 
-        @test coefnames(ff_c.rhs) ==  ["x(centered: 5.5 scaled: 3.03)",
-                                       "y(centered: 2.2 scaled: 5)",
-                                       "x(centered: 5.5 scaled: 3.03) & y(centered: 2.2 scaled: 5)"]
+        @test coefnames(ff_c.rhs) == ["x(centered: 5.5 scaled: 3.03)",
+                                      "y(centered: 2.2 scaled: 5)",
+                                      "x(centered: 5.5 scaled: 3.03) & y(centered: 2.2 scaled: 5)"]
 
         # round-trip schema is empty since needs_schema is false
         sch_2 = schema(ff_c, data)
@@ -102,7 +102,8 @@
     @testset "printing" begin
         xc = concrete_term(term(:x), data, ZScore())
         @test StatsModels.termsyms(xc) == Set([:x])
-        @test "$(xc)" == string_mime(MIME("text/plain"), xc) == "x(centered: 5.5 scaled: 3.03)"
+        @test "$(xc)" == string_mime(MIME("text/plain"), xc) ==
+              "x(centered: 5.5 scaled: 3.03)"
         @test coefnames(xc) == "x(centered: 5.5 scaled: 3.03)"
     end
 
@@ -110,14 +111,17 @@
         z = concrete_term(term(:z), data)
         @test_throws ArgumentError zscore(z)
         @test_throws ArgumentError zscore(z, ZScore())
-        zc = zscore(z, ZScore(center=0.5, scale=3))
+        zc = zscore(z, ZScore(; center=0.5, scale=3))
         @test modelcols(zc, data) ≈ (modelcols(z, data) .- 0.5) ./ 3
         @test StatsModels.width(zc) == StatsModels.width(z)
         @test coefnames(zc) == coefnames(z) .* "(centered: 0.5 scaled: 3)"
 
-        zc2 = zscore(z, ZScore(center=[1 2 3 4], scale=[5 6 7 8]))
-        @test string_mime(MIME("text/plain"), zc2) == "z(centered: [1 2 3 4] scaled: [5 6 7 8])"
+        zc2 = zscore(z, ZScore(; center=[1 2 3 4], scale=[5 6 7 8]))
+        @test string_mime(MIME("text/plain"), zc2) ==
+              "z(centered: [1 2 3 4] scaled: [5 6 7 8])"
         @test modelcols(zc2, data) ≈ (modelcols(z, data) .- [1 2 3 4]) ./ [5 6 7 8]
-        @test coefnames(zc2) == coefnames(z) .* "(centered: " .* string.([1, 2, 3, 4]) .* " scaled: " .* string.([5, 6, 7, 8]) .* ")"
+        @test coefnames(zc2) ==
+              coefnames(z) .* "(centered: " .* string.([1, 2, 3, 4]) .* " scaled: " .*
+              string.([5, 6, 7, 8]) .* ")"
     end
 end

--- a/test/zscoring.jl
+++ b/test/zscoring.jl
@@ -15,6 +15,14 @@
         @test yc.center ≈ mean(data.y)
         @test yc.scale ≈ std(data.y)
         @test modelcols(yc, data) ≈ zscore(data.y) ≈ zscore(data.y, yc.center, yc.scale)
+
+        @testset "alternative center and scale functions" begin
+            xc = concrete_term(term(:x), data, ZScore(median, mad))
+            @test xc isa ZScoredTerm
+            @test xc.center ≈ median(data.x)
+            @test xc.scale ≈ mad(data.x)
+            @test modelcols(xc, data) ≈ zscore(data.x, xc.center, xc.scale)
+        end
     end
 
     @testset "Manual scaling" begin

--- a/test/zscoring.jl
+++ b/test/zscoring.jl
@@ -16,11 +16,17 @@
         @test modelcols(yc, data) ≈ zscore(data.y) ≈ zscore(data.y, yc.center, yc.scale)
 
         @testset "alternative center and scale functions" begin
-            xc = concrete_term(term(:x), data, ZScore(median, mad))
+            f, g = first, mad
+            xc = concrete_term(term(:x), data, ZScore(f, g))
             @test xc isa ZScoredTerm
-            @test xc.center ≈ median(data.x)
-            @test xc.scale ≈ mad(data.x)
+            @test xc.center ≈ f(data.x)
+            @test xc.scale ≈ g(data.x)
             @test modelcols(xc, data) ≈ zscore(data.x, xc.center, xc.scale)
+            # why test this? well this makes sure that our tests
+            # wouldn't pass if we were using the default scale function
+            # in other words, this tests we're actually hitting a different codepath
+            @test !isapprox(mean(data.x), f(data.x))
+            @test !isapprox(std(data.x), g(data.x))
         end
     end
 


### PR DESCRIPTION
Closes #19 

- [x] `Center(::Function)`
- [x] `Scale(::Function)`
- [x] `ZScore(::Function)`
- [x] let JuliaFormatter have its YASG way 